### PR TITLE
dbus-pure: Remove some unnecessary Boxes.

### DIFF
--- a/benches/marshal_bench.rs
+++ b/benches/marshal_bench.rs
@@ -147,15 +147,17 @@ fn make_dbus_pure_message(parts: &MessageParts, send_it: bool) {
         fields: (&[][..]).into(),
     };
 
-    let dict_content: Vec<dbus_pure::proto::Variant> = parts
-        .dict
-        .iter()
+    let dict_content: Vec<_> =
+        parts.dict.iter()
+        .map(|(k, v)| (dbus_pure::proto::Variant::String(k.as_str().into()), dbus_pure::proto::Variant::I32(*v)))
+        .collect();
+    let dict_content: Vec<_> =
+        dict_content.iter()
         .map(|(k, v)| dbus_pure::proto::Variant::DictEntry {
-            key: Box::new(dbus_pure::proto::Variant::String(k.as_str().into())).into(),
-            value: Box::new(dbus_pure::proto::Variant::I32(*v)).into(),
+            key: k.into(),
+            value: v.into(),
         })
         .collect();
-
     let dict = dbus_pure::proto::Variant::Array {
         element_signature: dbus_pure::proto::Signature::DictEntry {
             key: Box::new(dbus_pure::proto::Signature::String),


### PR DESCRIPTION
Before:

```
MarshalMixed/marshal_dbus_pure      time:   [44.954 us 45.068 us 45.199 us]
MarshalBigArray/marshal_dbus_pure   time:   [9.8263 us 9.8861 us 9.9605 us]
Sending/send_dbus_pure              time:   [331.18 us 335.38 us 340.07 us]                                   

MarshalMixed/marshal_rustbus        time:   [29.261 us 29.384 us 29.509 us]
MarshalBigArray/marshal_rustbus     time:   [30.886 us 30.931 us 30.978 us]
Sending/send_rustbus                time:   [320.28 us 327.84 us 335.76 us]
```

After:

```
MarshalMixed/marshal_dbus_pure      time:   [36.014 us 36.204 us 36.415 us]
MarshalBigArray/marshal_dbus_pure   time:   [9.7584 us 9.7961 us 9.8379 us]
Sending/send_dbus_pure              time:   [322.75 us 329.47 us 336.13 us]                                   

MarshalMixed/marshal_rustbus        time:   [29.208 us 29.325 us 29.455 us]
MarshalBigArray/marshal_rustbus     time:   [29.970 us 30.054 us 30.141 us]
Sending/send_rustbus                time:   [311.93 us 316.24 us 320.35 us]
```