### PR TITLE
Add a zvariant_derive based bench

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ dbus-bytestream = "0.1.4"
 dbus-serialize = "0.1.2"
 
 zvariant = { git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0" }
+zvariant_derive = { git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0" }
+serde = { version = "1.0", features = [ "derive" ] }
 zbus = {git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0"}
 
 dbus-pure = {git = "https://github.com/Arnavion/dbus-pure", version = "0.1.0"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ dbus = "0.8.1"
 dbus-bytestream = "0.1.4"
 dbus-serialize = "0.1.2"
 
-zvariant = "^2"
+zvariant = { git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0" }
 zbus = {git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0"}
 
 dbus-pure = {git = "https://github.com/Arnavion/dbus-pure", version = "0.1.0"}


### PR DESCRIPTION
This eliminates the time it takes to create the data structures from the benchmark.

Fixes #8.