### PR TITLE
Use version rather than tags for zbus crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,10 @@ dbus = "0.8.1"
 dbus-bytestream = "0.1.4"
 dbus-serialize = "0.1.2"
 
-zvariant = { git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0" }
-zvariant_derive = { git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0" }
+zvariant = { git = "https://gitlab.freedesktop.org/zeenix/zbus", version = "2" }
+zvariant_derive = { git = "https://gitlab.freedesktop.org/zeenix/zbus", version = "2" }
 serde = { version = "1.0", features = [ "derive" ] }
-zbus = {git = "https://gitlab.freedesktop.org/zeenix/zbus", tag = "zvariant_derive-v2.0.0"}
+zbus = {git = "https://gitlab.freedesktop.org/zeenix/zbus", version = "1.0"}
 
 dbus-pure = {git = "https://github.com/Arnavion/dbus-pure", version = "0.1.0"}
 


### PR DESCRIPTION
So that the optimizations that are about to be pushed (and in future) are picked up and the latest git master is always used.