### PR TITLE
Update URL to zbus repo

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@ This repo tries to give an overview over the landscape of the the different dbus
 1. https://github.com/KillingSpark/rustbus
 1. https://github.com/diwic/dbus-rs/ (bindings to C library)
 1. https://github.com/diwic/dbus-rs/tree/master/dbus-native
-1. https://gitlab.freedesktop.org/zeenix/zbus/
+1. https://github.com/dbus2/zbus/
 1. https://github.com/Arnavion/dbus-pure
 1. https://github.com/srwalter/dbus-bytestream
 1. https://github.com/LinkTed/dbus-message-parser


### PR DESCRIPTION
zbus repository was moved to GH a while back.