### PR TITLE
Use zbus 5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,7 @@ dbus-bytestream = "0.1.4"
 dbus-serialize = "0.1.2"
 
 serde = "1.0.0"
-zvariant = "3.8.0"
-zvariant_derive = "3.8.0"
-zbus = "3.5.0"
+zbus = "5"
 
 dbus-pure = {git = "https://github.com/Arnavion/dbus-pure", rev = "cd238a268095e560801048332d82c5ec208f4e44"}
 

--- a/src/bench_zvariant.rs
+++ b/src/bench_zvariant.rs
@@ -16,22 +16,18 @@ pub fn make_zvariant_message(parts: &MessageParts, send_it: bool) -> Option<zbus
         );
         elements.push(element);
     }
-    let sender: Option<&str> = None;
     let msg = zbus::Message::signal(
-        sender,
-        Some(parts.interface.as_str()),
         parts.object.as_str(),
         parts.interface.as_str(),
         parts.member.as_str(),
-        &elements,
     )
+    .unwrap()
+    .build(&elements)
     .unwrap();
 
     if send_it {
-        async_std::task::block_on(async {
-            let con = zbus::Connection::session().await.unwrap();
-            con.send_message(msg).await.unwrap();
-        });
+        let con = zbus::blocking::Connection::session().unwrap();
+        con.send(&msg).unwrap();
         None
     } else {
         Some(msg)
@@ -39,7 +35,7 @@ pub fn make_zvariant_message(parts: &MessageParts, send_it: bool) -> Option<zbus
 }
 
 use serde::{Deserialize, Serialize};
-use zvariant_derive::Type;
+use zbus::zvariant::Type;
 
 #[derive(Deserialize, Serialize, Type, PartialEq, Debug, Clone)]
 pub struct ZVField {
@@ -62,21 +58,17 @@ pub fn make_zvariant_derive_message(
     elements: &[ZVStruct],
     send_it: bool,
 ) -> Option<zbus::Message> {
-    let sender: Option<&str> = None;
     let msg = zbus::Message::signal(
-        sender,
-        Some(parts.interface.as_str()),
         parts.object.as_str(),
         parts.interface.as_str(),
         parts.member.as_str(),
-        &elements,
     )
+    .unwrap()
+    .build(&elements)
     .unwrap();
     if send_it {
-        async_std::task::block_on(async {
-            let con = zbus::Connection::session().await.unwrap();
-            con.send_message(msg).await.unwrap();
-        });
+        let con = zbus::blocking::Connection::session().unwrap();
+        con.send(&msg).unwrap();
         None
     } else {
         Some(msg)


### PR DESCRIPTION
This comes with massive performance improvements to (de)serialization code so it would be fair to use it instead of old zbus. zbus 5 (4 actually) also heavily optimized connection setup so at least on my machine (Fedora 40), the bus seems to disconnect us for connecting and disconnecting too often too fast. :) The results on my machine:

```
MarshalMixed/marshal_zvariant
                        time:   [7.1888 µs 7.2033 µs 7.2187 µs]
                        change: [-79.283% -78.800% -78.327%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe
MarshalMixed/marshal_zvariant_derive
                        time:   [7.5009 µs 7.5158 µs 7.5325 µs]
                        change: [-78.553% -78.203% -77.887%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe

MarshalBigArray/marshal_zvariant
                        time:   [41.789 µs 41.920 µs 42.075 µs]
                        change: [-82.874% -82.436% -82.044%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  6 (6.00%) high mild
  6 (6.00%) high severe
MarshalBigArray/marshal_zvariant_derive
                        time:   [41.388 µs 41.465 µs 41.559 µs]
                        change: [-82.892% -82.624% -82.350%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

MarshalBigStrArray/marshal_zvariant
                        time:   [157.49 µs 157.85 µs 158.24 µs]
                        change: [-64.621% -64.168% -63.699%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe
MarshalBigStrArray/marshal_zvariant_derive
                        time:   [156.86 µs 157.23 µs 157.64 µs]
                        change: [-65.228% -64.556% -63.977%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  2 (2.00%) low mild
  7 (7.00%) high mild
  5 (5.00%) high severe

Sending/send_zvariant   time:   [169.74 µs 170.88 µs 171.96 µs]
                        change: [-28.188% -26.857% -25.372%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  4 (4.00%) high mild
  2 (2.00%) high severe
Benchmarking Sending/send_zvariant_derive: Warming up for 3.0000 sthread 'main' panicked at src/bench_zvariant.rs:70:57:
called `Result::unwrap()` on an `Err` value: InputOutput(Os { code: 11, kind: WouldBlock, message: "Resource temporarily unavailable" })
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Running the last benchmark in isolation usually works fine though:

```
ending/send_zvariant_derive
                        time:   [166.09 µs 167.11 µs 168.16 µs]
                        change: [-32.144% -30.755% -29.213%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  2 (2.00%) low severe
  2 (2.00%) low mild
  2 (2.00%) high mild
  4 (4.00%) high severe
```